### PR TITLE
use non navbar default layout

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
-import { Layout } from '@/components/layout/Layout'
+import { AppProvider } from '@/components/layout/AppProvider'
+import { Footer } from '@/components/layout/Footer'
 import { AppProps } from 'next/app'
 import localFont from 'next/font/local'
 import '../styles/globals.css'
@@ -23,7 +24,7 @@ const agrandir = localFont({
   src: [
     {
       path: '../../public/assets/fonts/PPAgrandir-Medium.woff2',
-      weight: '400',
+      weight: '500',
       style: 'normal',
     },
   ],
@@ -48,12 +49,13 @@ const beatrice = localFont({
 
 export default function JuicecrowdApp({ Component, pageProps }: AppProps) {
   return (
-    <Layout>
-      <div
-        className={`${agrandirWide.variable} ${agrandir.variable} ${beatrice.variable}`}
+    <AppProvider>
+      <main
+        className={`${beatrice.variable} ${agrandir.variable} ${agrandirWide.variable} font-body text-base md:text-sm`}
       >
         <Component {...pageProps} />
-      </div>
-    </Layout>
+      </main>
+      <Footer />
+    </AppProvider>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,11 @@
+import { Navbar } from '@/components/layout/Navbar'
+
 export function Page() {
   return (
-    <h1 className="font-heading text-7xl font-bold underline">Juicecrowd</h1>
+    <>
+      <Navbar />
+      <h1 className="font-heading text-7xl font-bold underline">Juicecrowd</h1>
+    </>
   )
 }
 


### PR DESCRIPTION
### Description

This change is made to avoid having the need for the default nav bar on all pages and moves to the page itself. This is due to pages in the design having different 'nav bars'
