### PR TITLE
fix: currency amount tooltip does not show on reward dialog open

### DIFF
--- a/src/components/CurrencyAmount.tsx
+++ b/src/components/CurrencyAmount.tsx
@@ -79,11 +79,11 @@ export const CurrencyAmount: React.FC<CurrencyAmountProps> = ({
   return (
     <TooltipProvider delayDuration={150}>
       <Tooltip>
-        <TooltipTrigger
-          className={twMerge('inline-flex w-fit items-center', className)}
-        >
-          {currencyIcon}
-          {formattedAmounts[0]}
+        <TooltipTrigger asChild>
+          <div className={twMerge('inline-flex w-fit items-center', className)}>
+            {currencyIcon}
+            {formattedAmounts[0]}
+          </div>
         </TooltipTrigger>
         <TooltipContent className="flex items-center">
           {formattedAmounts[1]}


### PR DESCRIPTION
### Description

There was a bug where the tooltip would show on the dialog/model opening. This no longer happens with this fix