### PR TITLE
[4/n] Manage dashboard: Mobile styles

### DIFF
--- a/src/components/ManageProject/ManageCardsGrid.tsx
+++ b/src/components/ManageProject/ManageCardsGrid.tsx
@@ -66,7 +66,7 @@ export function ManageCardsGrid() {
   ]
 
   return (
-    <div className="grid grid-cols-3 gap-4">
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
       {cardData.map((cardData, index) => (
         <ManageCard key={index} name={cardData.name} value={cardData.value} />
       ))}

--- a/src/components/ManageProject/ManageDashboard.tsx
+++ b/src/components/ManageProject/ManageDashboard.tsx
@@ -1,29 +1,26 @@
-import { ManageHeader } from "./ManageHeader"
-import { Button } from "@/components/ui/Button"
-import { ManageProjectDetails } from "./ManageProjectDetails"
-import { ManageCardsGrid } from "./ManageCardsGrid"
-import { Link } from "@/components/Link"
-import { DISCORD_INVITE_URL } from "@/components/layout/Footer"
-import { WithdrawButton } from "./WithdrawButton"
+import { ManageHeader } from './ManageHeader'
+import { Button } from '@/components/ui/Button'
+import { ManageProjectDetails } from './ManageProjectDetails'
+import { ManageCardsGrid } from './ManageCardsGrid'
+import { Link } from '@/components/Link'
+import { DISCORD_INVITE_URL } from '@/components/layout/Footer'
+import { WithdrawButton } from './WithdrawButton'
 
 export function ManageDashboard() {
   return (
     <>
       <ManageHeader />
-      <div className="flex flex-col mx-auto max-w-4xl gap-10">
-        <div className="flex justify-between">
+      <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 md:gap-10 md:px-6">
+        <div className="flex flex-col justify-between gap-20 md:flex-row md:gap-0">
           <ManageProjectDetails />
           <WithdrawButton />
         </div>
         <ManageCardsGrid />
-        <div className='text-gray-600 mt-5'>
-          Need to make changes to your project? Please{' '} 
-          <Link href={DISCORD_INVITE_URL}>
-            contact us
-          </Link>.
+        <div className="pb-10 pt-5 text-gray-600 md:pb-0">
+          Need to make changes to your project? Please{' '}
+          <Link href={DISCORD_INVITE_URL}>contact us</Link>.
         </div>
       </div>
     </>
   )
 }
-

--- a/src/components/ManageProject/ManageProjectDetails.tsx
+++ b/src/components/ManageProject/ManageProjectDetails.tsx
@@ -6,16 +6,16 @@ import { useJbProject } from '@/hooks/useJbProject'
 export function ManageProjectDetails() {
   const { logoUri, name, projectId } = useJbProject()
   return (
-    <div className="flex items-center gap-4">
+    <div className="flex flex-col gap-4 md:flex-row md:items-center">
       <ProjectLogo
-        className="relative flex h-20 w-20 rounded-xl border-[6px] border-white"
+        className="relative flex h-20 w-20 rounded-xl border-white"
         projectId={projectId}
         uri={logoUri}
         name={name}
       />
       <div className="flex h-16 flex-col justify-between">
         <h1 className="font-heading text-2xl font-medium">{name}</h1>
-        <div className="flex items-center gap-5">
+        <div className="flex flex-col gap-5 md:flex-row md:items-center">
           <ProjectHeaderMetadata />
           <ProgressBadge />
         </div>

--- a/src/components/ManageProject/WithdrawButton.tsx
+++ b/src/components/ManageProject/WithdrawButton.tsx
@@ -72,6 +72,7 @@ export function WithdrawButton() {
               contractWrite.isLoading
             }
             onClick={handleWithdraw}
+            className="w-full"
           >
             Withdraw funds
           </LoadingButton>

--- a/src/components/Project/components/ProgressBadge.tsx
+++ b/src/components/Project/components/ProgressBadge.tsx
@@ -5,7 +5,7 @@ export function ProgressBadge() {
   const { isComplete } = useCampaignEndDate()
 
   return (
-    <Badge variant={isComplete ? 'success' : 'warn'}>
+    <Badge variant={isComplete ? 'success' : 'warn'} className="w-min">
       {isComplete ? 'Complete' : 'In progress'}
     </Badge>
   )


### PR DESCRIPTION
Implement mobile designs for `/manage` dashboard according to: [Strath's Figma](https://www.figma.com/file/tKUGbpnRRRNPqf4qpmsprZ/Juicecrowd-%E2%80%93-Landing-Page?type=design&node-id=1347-40827&mode=design&t=XQUKnOfm9LWlaXrQ-0)


https://github.com/peeldao/juicecrowd/assets/96150256/cc8e0fe7-89da-4e10-876e-564ade84257f

