### PR TITLE
reduce mobile cover image max height to 220px

### DIFF
--- a/src/components/Project/components/CoverPhoto.tsx
+++ b/src/components/Project/components/CoverPhoto.tsx
@@ -16,7 +16,7 @@ export const CoverPhoto = () => {
     <div
       className={twMerge(
         'relative w-full',
-        hasCoverImage ? 'h-72 bg-orange-200' : 'h-[168px]',
+        hasCoverImage ? 'h-56 bg-orange-200 md:h-72' : 'h-[168px]',
       )}
     >
       {coverImageUrl && (


### PR DESCRIPTION
Closes [JB-842 : reduce mobile cover image max height to 220px](https://linear.app/peel/issue/JB-842/reduce-mobile-cover-image-max-height-to-220px)
