### PR TITLE
fix: use tagline in meta og:description tags on project pages

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,3 +21,26 @@ export function cnTextHw(className: string | undefined) {
     className.includes('text-xs') && 'h-3 w-3',
   ]
 }
+
+/**
+ * Removes headers and HTML tags from a string for use in e.g. meta og:description tags.
+ * @param description - The description to sanitize.
+ * @returns The sanitized description.
+ */
+export function sanitizeDescriptionContent(description: string) {
+  // If there are no HTML tags, return the text as-is.
+  const containsHtml = /<[^>]*>?/m.test(description)
+  if (!containsHtml) return description
+
+  // Remove headers and text within them. Headers don't make sense in descriptions.
+  const headerRegex = /<h[1-3]>(.*?)<\/h[1-3]>/g
+  let headerMatch
+  while ((headerMatch = headerRegex.exec(description)) !== null) {
+    description = description.replace(headerMatch[0], '')
+  }
+
+  // Remove all HTML tags from the description.
+  description = description.replace(/<[^>]*>?/gm, '')
+
+  return description
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,26 +21,3 @@ export function cnTextHw(className: string | undefined) {
     className.includes('text-xs') && 'h-3 w-3',
   ]
 }
-
-/**
- * Removes headers and HTML tags from a string for use in e.g. meta og:description tags.
- * @param description - The description to sanitize.
- * @returns The sanitized description.
- */
-export function sanitizeDescriptionContent(description: string) {
-  // If there are no HTML tags, return the text as-is.
-  const containsHtml = /<[^>]*>?/m.test(description)
-  if (!containsHtml) return description
-
-  // Remove headers and text within them. Headers don't make sense in descriptions.
-  const headerRegex = /<h[1-3]>(.*?)<\/h[1-3]>/g
-  let headerMatch
-  while ((headerMatch = headerRegex.exec(description)) !== null) {
-    description = description.replace(headerMatch[0], '')
-  }
-
-  // Remove all HTML tags from the description.
-  description = description.replace(/<[^>]*>?/gm, '')
-
-  return description
-}

--- a/src/pages/p/[projectId]/index.tsx
+++ b/src/pages/p/[projectId]/index.tsx
@@ -18,20 +18,11 @@ export default function Page({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const pid = projectId ? BigInt(projectId) : 0n
 
-  let croppedTagline = ''
-  if (metadata.projectTagline) {
-    croppedTagline = metadata.projectTagline.substring(0, 160)
-    if (croppedTagline !== metadata.projectTagline) {
-      croppedTagline =
-        croppedTagline.substring(0, croppedTagline.lastIndexOf(' ')) + '...'
-    }
-  }
-
   return (
     <>
       <SEO
         title={metadata.name ? metadata.name : 'Juicecrowd Project'}
-        description={croppedTagline}
+        description={metadata.projectTagline ? metadata.projectTagline : ''}
         twitter={{
           card: 'summary',
           creator: metadata.twitter,

--- a/src/pages/p/[projectId]/index.tsx
+++ b/src/pages/p/[projectId]/index.tsx
@@ -7,6 +7,7 @@ import {
   projectGetStaticProps,
 } from '@/lib/backend/static/projects'
 import { ipfsUriToGatewayUrl } from '@/lib/ipfs'
+import { sanitizeDescriptionContent } from '@/lib/utils'
 import { InferGetStaticPropsType } from 'next'
 
 export const getStaticPaths = projectGetStaticPaths
@@ -17,13 +18,16 @@ export default function Page({
   metadata,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const pid = projectId ? BigInt(projectId) : 0n
+  // Sanitize before slicing to prevent partial HTML tags at the end.
+  const sanitizedDescription = metadata?.description
+    ? sanitizeDescriptionContent(metadata.description).slice(0, 160)
+    : ''
+
   return (
     <>
       <SEO
         title={metadata.name ? metadata.name : 'Juicecrowd Project'}
-        description={
-          metadata.description ? metadata.description.slice(0, 160) : ''
-        }
+        description={sanitizedDescription}
         twitter={{
           card: 'summary',
           creator: metadata.twitter,

--- a/src/pages/p/[projectId]/index.tsx
+++ b/src/pages/p/[projectId]/index.tsx
@@ -7,7 +7,6 @@ import {
   projectGetStaticProps,
 } from '@/lib/backend/static/projects'
 import { ipfsUriToGatewayUrl } from '@/lib/ipfs'
-import { sanitizeDescriptionContent } from '@/lib/utils'
 import { InferGetStaticPropsType } from 'next'
 
 export const getStaticPaths = projectGetStaticPaths
@@ -18,16 +17,21 @@ export default function Page({
   metadata,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const pid = projectId ? BigInt(projectId) : 0n
-  // Sanitize before slicing to prevent partial HTML tags at the end.
-  const sanitizedDescription = metadata?.description
-    ? sanitizeDescriptionContent(metadata.description).slice(0, 160)
-    : ''
+
+  let croppedTagline = ''
+  if (metadata.projectTagline) {
+    croppedTagline = metadata.projectTagline.substring(0, 160)
+    if (croppedTagline !== metadata.projectTagline) {
+      croppedTagline =
+        croppedTagline.substring(0, croppedTagline.lastIndexOf(' ')) + '...'
+    }
+  }
 
   return (
     <>
       <SEO
         title={metadata.name ? metadata.name : 'Juicecrowd Project'}
-        description={sanitizedDescription}
+        description={croppedTagline}
         twitter={{
           card: 'summary',
           creator: metadata.twitter,


### PR DESCRIPTION
This PR previously added utils to remove specific HTML tags from descriptions. Now, it just uses the tagline.