### PR TITLE
feat: add perks button

### DIFF
--- a/src/components/Project/components/RewardCard.tsx
+++ b/src/components/Project/components/RewardCard.tsx
@@ -54,7 +54,7 @@ export const RewardCard: React.FC<RewardCardProps> = ({ className, nft }) => {
             <DialogTrigger>
               <div className="flex items-center gap-0.5 text-end text-gray-400 hover:text-blue-400">
                 <InformationCircleIcon className="h-5 w-5" />
-                Perks
+                Details
               </div>
             </DialogTrigger>
           </div>

--- a/src/components/Project/components/RewardCard.tsx
+++ b/src/components/Project/components/RewardCard.tsx
@@ -9,6 +9,7 @@ import { useCallback } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { RewardDialogContent } from './RewardDialogContent'
 import { RewardImage } from './RewardImage'
+import { InformationCircleIcon } from '@heroicons/react/24/outline'
 
 export type RewardCardProps = {
   className?: string
@@ -46,8 +47,16 @@ export const RewardCard: React.FC<RewardCardProps> = ({ className, nft }) => {
           />
         </DialogTrigger>
         <div className="flex flex-col gap-4 p-4 pb-5">
-          <div className="text-base font-medium text-gray-900">
-            {nft.metadata.name}
+          <div className="flex items-center justify-between gap-5">
+            <div className="text-base font-medium text-gray-900">
+              {nft.metadata.name}
+            </div>
+            <DialogTrigger>
+              <div className="flex items-center gap-1 text-end text-gray-400 hover:text-blue-400">
+                <InformationCircleIcon className="h-5 w-5" />
+                Perks
+              </div>
+            </DialogTrigger>
           </div>
           <div className="flex items-center justify-between gap-5">
             <CurrencyAmount

--- a/src/components/Project/components/RewardCard.tsx
+++ b/src/components/Project/components/RewardCard.tsx
@@ -52,7 +52,7 @@ export const RewardCard: React.FC<RewardCardProps> = ({ className, nft }) => {
               {nft.metadata.name}
             </div>
             <DialogTrigger>
-              <div className="flex items-center gap-0.5 text-end text-gray-400 hover:text-blue-400">
+              <div className="flex items-center gap-0.5 text-end text-gray-400 group-hover:text-blue-400">
                 <InformationCircleIcon className="h-5 w-5" />
                 Details
               </div>

--- a/src/components/Project/components/RewardCard.tsx
+++ b/src/components/Project/components/RewardCard.tsx
@@ -46,7 +46,7 @@ export const RewardCard: React.FC<RewardCardProps> = ({ className, nft }) => {
             alt={nft.metadata.name}
           />
         </DialogTrigger>
-        <div className="group flex flex-col gap-4 p-4 pb-5">
+        <div className="flex flex-col gap-4 p-4 pb-5">
           <DialogTrigger className="flex w-full flex-col gap-4">
             <div className="flex w-full items-center justify-between gap-5">
               <div className="text-start text-base font-medium text-gray-900 group-hover:underline">

--- a/src/components/Project/components/RewardCard.tsx
+++ b/src/components/Project/components/RewardCard.tsx
@@ -52,7 +52,7 @@ export const RewardCard: React.FC<RewardCardProps> = ({ className, nft }) => {
               {nft.metadata.name}
             </div>
             <DialogTrigger>
-              <div className="flex items-center gap-1 text-end text-gray-400 hover:text-blue-400">
+              <div className="flex items-center gap-0.5 text-end text-gray-400 hover:text-blue-400">
                 <InformationCircleIcon className="h-5 w-5" />
                 Perks
               </div>

--- a/src/components/Project/components/RewardCard.tsx
+++ b/src/components/Project/components/RewardCard.tsx
@@ -46,26 +46,26 @@ export const RewardCard: React.FC<RewardCardProps> = ({ className, nft }) => {
             alt={nft.metadata.name}
           />
         </DialogTrigger>
-        <div className="flex flex-col gap-4 p-4 pb-5">
-          <div className="flex items-center justify-between gap-5">
-            <div className="text-base font-medium text-gray-900">
-              {nft.metadata.name}
-            </div>
-            <DialogTrigger>
-              <div className="flex items-center gap-0.5 text-end text-gray-400 group-hover:text-blue-400">
+        <div className="group flex flex-col gap-4 p-4 pb-5">
+          <DialogTrigger className="flex w-full flex-col gap-4">
+            <div className="flex w-full items-center justify-between gap-5">
+              <div className="text-start text-base font-medium text-gray-900">
+                {nft.metadata.name}
+              </div>
+              <div className="flex items-center gap-0.5 text-end text-gray-400 group-hover:text-blue-500">
                 <InformationCircleIcon className="h-5 w-5" />
                 Details
               </div>
-            </DialogTrigger>
-          </div>
-          <div className="flex items-center justify-between gap-5">
-            <CurrencyAmount
-              className="text-base font-medium text-gray-800"
-              amount={nft.price}
-              currency={JB_CURRENCIES.USD}
-            />
-            <div className="text-end text-gray-400">{remainingText}</div>
-          </div>
+            </div>
+            <div className="flex w-full items-center justify-between gap-5">
+              <CurrencyAmount
+                className="text-base font-medium text-gray-800"
+                amount={nft.price}
+                currency={JB_CURRENCIES.USD}
+              />
+              <div className="text-end text-gray-400">{remainingText}</div>
+            </div>
+          </DialogTrigger>
           <Button
             variant="outline"
             size="xs"


### PR DESCRIPTION
![image](https://github.com/peeldao/juicecrowd/assets/96905094/0e826784-4ab3-4fcf-a81b-434cae2248db)

If I didn't already know to click on this image to see its perks, I would not have found them.

To address this, I added a small "Perks" button:

![image](https://github.com/peeldao/juicecrowd/assets/96905094/e4e002ef-010d-4a21-8a29-879fc8e79219)


It becomes blue when hovered, and opens the dialog when clicked.