### PR TITLE
feat: details button on reward card

### DIFF
--- a/src/components/Project/components/RewardCard.tsx
+++ b/src/components/Project/components/RewardCard.tsx
@@ -34,7 +34,7 @@ export const RewardCard: React.FC<RewardCardProps> = ({ className, nft }) => {
     <Dialog>
       <div
         className={twMerge(
-          'group w-72 rounded-lg border border-gray-200 shadow-card transition-all hover:-translate-y-1 hover:shadow-cardHover',
+          'w-72 rounded-lg border border-gray-200 shadow-card',
           className,
         )}
       >
@@ -46,7 +46,7 @@ export const RewardCard: React.FC<RewardCardProps> = ({ className, nft }) => {
           />
         </DialogTrigger>
         <div className="flex flex-col gap-4 p-4 pb-5">
-          <div className="text-base font-medium text-gray-900 group-hover:underline">
+          <div className="text-base font-medium text-gray-900">
             {nft.metadata.name}
           </div>
           <div className="flex items-center justify-between gap-5">
@@ -57,17 +57,28 @@ export const RewardCard: React.FC<RewardCardProps> = ({ className, nft }) => {
             />
             <div className="text-end text-gray-400">{remainingText}</div>
           </div>
-          <Button
-            variant="outline"
-            size="xs"
-            className="text-gray-700"
-            onClick={e => {
-              e.stopPropagation()
-              goToPayPage()
-            }}
-          >
-            Claim reward
-          </Button>
+          <div className="flex w-full items-center gap-3">
+            <DialogTrigger className="w-full outline-none">
+              <Button
+                variant="outline"
+                size="xs"
+                className="w-full text-gray-700"
+              >
+                Details
+              </Button>
+            </DialogTrigger>
+            <Button
+              variant="default"
+              size="xs"
+              className="w-full text-white"
+              onClick={e => {
+                e.stopPropagation()
+                goToPayPage()
+              }}
+            >
+              Claim
+            </Button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
- Reverts ccc6e5f0ffe2e40b13359904e6a1e7c016c2a254
- Details button to show dialog on rewards card
- Ensure no black border is shown after closing dialog

![image](https://github.com/peeldao/juicecrowd/assets/96905094/daaff930-685a-4dab-894a-d53d26deb7be)

Suggested by Strath here: https://discord.com/channels/939317843059679252/1177799622450757672/1177811768836362301