### PR TITLE
fix: NFT reward modal wrapping words

### DIFF
--- a/src/components/Project/components/RewardDialogContent.tsx
+++ b/src/components/Project/components/RewardDialogContent.tsx
@@ -55,7 +55,7 @@ export const RewardDialogContent: React.FC<RewardDialogProps> = ({
 
       <DialogDescription className="text-base text-gray-600">
         {nft.metadata.description?.split('\n').map((line, i) => (
-          <p className="mb-2 hyphens-auto break-words break-all" key={i}>
+          <p className="mb-2 hyphens-auto" key={i}>
             {line}
           </p>
         ))}


### PR DESCRIPTION
BEFORE:
<img width="501" alt="Screen Shot 2023-11-26 at 12 35 05 pm" src="https://github.com/peeldao/juicecrowd/assets/96150256/a6fe6e69-e742-4bcf-a2b8-ba015f0796f6">

<img width="502" alt="Screen Shot 2023-11-26 at 12 37 36 pm" src="https://github.com/peeldao/juicecrowd/assets/96150256/86befbd5-bc2b-4ded-9616-5909b45c5971">

AFTER:
<img width="520" alt="Screen Shot 2023-11-26 at 12 34 51 pm" src="https://github.com/peeldao/juicecrowd/assets/96150256/7700a113-31c9-478e-9ca5-35c3b298b647">
